### PR TITLE
Fix app config loaded too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for incuna-epatient-api
 
+## 0.1.2 (Upcoming)
+
+* Fix app config loaded too early.
+
 ## 0.1.1
 
 * Add missing init file which prevents to have the management commands.

--- a/user_deletion/managers.py
+++ b/user_deletion/managers.py
@@ -1,12 +1,11 @@
 from dateutil.relativedelta import relativedelta
+from django.apps import apps
 from django.utils import timezone
 
 
 class UserDeletionManagerMixin:
     def users_to_notify(self):
         """Finds all users who have been inactive and not yet notified."""
-        from django.apps import apps
-
         user_deletion_config = apps.get_app_config('user_deletion')
 
         threshold = timezone.now() - relativedelta(
@@ -16,8 +15,6 @@ class UserDeletionManagerMixin:
 
     def users_to_delete(self):
         """Finds all users who have been inactive and were notified."""
-        from django.apps import apps
-
         user_deletion_config = apps.get_app_config('user_deletion')
 
         threshold = timezone.now() - relativedelta(

--- a/user_deletion/managers.py
+++ b/user_deletion/managers.py
@@ -1,14 +1,14 @@
 from dateutil.relativedelta import relativedelta
-from django.apps import apps
 from django.utils import timezone
-
-
-user_deletion_config = apps.get_app_config('user_deletion')
 
 
 class UserDeletionManagerMixin:
     def users_to_notify(self):
         """Finds all users who have been inactive and not yet notified."""
+        from django.apps import apps
+
+        user_deletion_config = apps.get_app_config('user_deletion')
+
         threshold = timezone.now() - relativedelta(
             months=user_deletion_config.MONTH_NOTIFICATION,
         )
@@ -16,6 +16,10 @@ class UserDeletionManagerMixin:
 
     def users_to_delete(self):
         """Finds all users who have been inactive and were notified."""
+        from django.apps import apps
+
+        user_deletion_config = apps.get_app_config('user_deletion')
+
         threshold = timezone.now() - relativedelta(
             months=user_deletion_config.MONTH_DELETION,
         )


### PR DESCRIPTION
When importing the manager in a `models.py` under Django 1.8 the following error is raised:

``` python
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```
