### PR TITLE
Allow to customise notification classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for incuna-epatient-api
 
+## 0.2.0 (Upcoming)
+
+* Make notification classes available in the app config.
+
 ## 0.1.5
 
 * Fix typo for domain name in email notification.

--- a/user_deletion/apps.py
+++ b/user_deletion/apps.py
@@ -1,5 +1,7 @@
 from django.apps import AppConfig
 
+from .notifications import AccountDeletedNotification, AccountInactiveNotification
+
 
 class UserDeletionConfig(AppConfig):
     name = 'user_deletion'
@@ -8,3 +10,6 @@ class UserDeletionConfig(AppConfig):
     MONTH_NOTIFICATION = 12
     # users are deleted after 13 months
     MONTH_DELETION = 13
+
+    deletion_notification_class = AccountDeletedNotification
+    inactive_notification_class = AccountInactiveNotification

--- a/user_deletion/management/commands/delete_users.py
+++ b/user_deletion/management/commands/delete_users.py
@@ -1,12 +1,12 @@
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 from django.utils import translation
 
-from ...notifications import AccountDeletedNotification
-
 User = get_user_model()
+user_deletion_config = apps.get_app_config('user_deletion')
 
 
 class Command(BaseCommand):
@@ -14,5 +14,9 @@ class Command(BaseCommand):
         translation.activate(settings.LANGUAGE_CODE)
         users = User.objects.users_to_delete()
         site = Site.objects.get_current()
-        AccountDeletedNotification(user=None, site=site, users=users).notify()
+        user_deletion_config.deletion_notification_class(
+            user=None,
+            site=site,
+            users=users,
+        ).notify()
         users.delete()

--- a/user_deletion/management/commands/notify_users.py
+++ b/user_deletion/management/commands/notify_users.py
@@ -1,12 +1,13 @@
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 from django.utils import translation
 
-from ...notifications import AccountInactiveNotification
 
 User = get_user_model()
+user_deletion_config = apps.get_app_config('user_deletion')
 
 
 class Command(BaseCommand):
@@ -14,5 +15,9 @@ class Command(BaseCommand):
         translation.activate(settings.LANGUAGE_CODE)
         users = User.objects.users_to_notify()
         site = Site.objects.get_current()
-        AccountInactiveNotification(user=None, site=site, users=users).notify()
+        user_deletion_config.inactive_notification_class(
+            user=None,
+            site=site,
+            users=users,
+        ).notify()
         users.update(notified=True)


### PR DESCRIPTION
Customising notification classes in the app config will allow to define custom handlers to send other kind of notifications (such as SMS).
